### PR TITLE
Fix template processing on environments where root is not a superuser

### DIFF
--- a/src/api-umbrella/cli/setup.lua
+++ b/src/api-umbrella/cli/setup.lua
@@ -206,9 +206,8 @@ local function write_templates()
           -- processes never read a half-written file.
           local install_dir = path.dirname(install_path)
           local temp_path = path.tmpname()
-          file.write(temp_path, "")
-          set_template_permissions(temp_path, install_filename, install_path)
           file.write(temp_path, content)
+          set_template_permissions(temp_path, install_filename, install_path)
 
           dir.makepath(install_dir)
           file.move(temp_path, install_path)


### PR DESCRIPTION
Currently, the docker image for API umbrella starts running using the root user and then it switches to the configured user (api-umbrella by default) for running the embedded services. The process manager is thus running using the root user and its the one responsable of processing configuration templates.

The problem raises because when API umbrella process the templates, they do the following steps to ensure the file is not read using a partial content:
1. Creates an empty temporal file
2. Sets the final ownership and permissions to the file
3. Fill the file with the rendered contents
4. Moves the temporal file to the final location

The problem with this schema, is that step 3 fails if the root user is not a superuser. When root is a superuser, she is allowed to do anything without taking into account file ownership/permissions, but step 2 usually sets permissions disallowing root to write to the file. The symptom in this case is that the final file is empty and you see errors like NREL/api-umbrella#339.

This PR fixes this by creating the file with the final contents as the first step.