### PR TITLE
set docker user to non-root

### DIFF
--- a/Dockerfile-build
+++ b/Dockerfile-build
@@ -1,6 +1,6 @@
 FROM ubuntu:18.04 AS build
 
-ENV MAXMIND_LICENSE_KEY <LICENSE>
+ENV MAXMIND_LICENSE_KEY CInU1dFAYh8alsUD
 
 RUN mkdir -p /app/build /build/.task /build/build/work
 RUN ln -snf /build/.task /app/.task
@@ -59,6 +59,8 @@ RUN groupadd -r api-umbrella && \
 
 ENV PATH "/app/bin:/build/build/work/dev-env/sbin:/build/build/work/dev-env/bin:/build/build/work/test-env/sbin:/build/build/work/test-env/bin:/build/build/work/stage/opt/api-umbrella/sbin:/build/build/work/stage/opt/api-umbrella/bin:/build/build/work/stage/opt/api-umbrella/embedded/sbin:/build/build/work/stage/opt/api-umbrella/embedded/bin:${PATH}"
 ENV API_UMBRELLA_ROOT /build/build/work/stage/opt/api-umbrella
+
+USER api-umbrella
 
 ENTRYPOINT ["/app/docker/docker-entrypoint"]
 CMD ["/app/docker/dev/docker-start"]

--- a/Dockerfile-build
+++ b/Dockerfile-build
@@ -1,6 +1,6 @@
 FROM ubuntu:18.04 AS build
 
-ENV MAXMIND_LICENSE_KEY CInU1dFAYh8alsUD
+ENV MAXMIND_LICENSE_KEY <LICENSE>
 
 RUN mkdir -p /app/build /build/.task /build/build/work
 RUN ln -snf /build/.task /app/.task

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,16 +1,10 @@
 FROM debian:jessie
 
-ARG USER=1000655000
-
 ENV API_UMBRELLA_VERSION 0.14.4-1~jessie
 
 # Install API Umbrella
 RUN echo "deb http://dl.bintray.com/nrel/api-umbrella-debian jessie main" >> /etc/apt/sources.list.d/api-umbrella.list
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y --no-install-recommends --allow-unauthenticated install api-umbrella
-
-RUN chmod -R o+rw /opt/api-umbrella
-
-USER ${USER}
 
 # Define mountable directories
 VOLUME ["/etc/api-umbrella", "/opt/api-umbrella/var/db", "/opt/api-umbrella/var/log"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,10 +1,16 @@
 FROM debian:jessie
 
+ARG USER=1000655000
+
 ENV API_UMBRELLA_VERSION 0.14.4-1~jessie
 
 # Install API Umbrella
 RUN echo "deb http://dl.bintray.com/nrel/api-umbrella-debian jessie main" >> /etc/apt/sources.list.d/api-umbrella.list
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y --no-install-recommends --allow-unauthenticated install api-umbrella
+
+RUN chmod -R o+rw /opt/api-umbrella
+
+USER ${USER}
 
 # Define mountable directories
 VOLUME ["/etc/api-umbrella", "/opt/api-umbrella/var/db", "/opt/api-umbrella/var/log"]


### PR DESCRIPTION
Docker container should run as non-root user for security reasons. Current container will for example not work on openshift. 